### PR TITLE
Added type-hints

### DIFF
--- a/Libravatar/LibravatarPlugin.php
+++ b/Libravatar/LibravatarPlugin.php
@@ -30,7 +30,7 @@ if (!defined('STATUSNET') && !defined('LACONICA')) {
 
 class LibravatarPlugin extends Plugin
 {
-    function onEndProfileGetAvatar($profile, $size, &$avatar)
+    function onEndProfileGetAvatar(Profile $profile, $size, Avatar &$avatar=null)
     {
         if (empty($avatar)) {
             try {


### PR DESCRIPTION
This small commit will add type-hints which prevents calling a method/function with wrong parameter types. "=null" is required as it initially is called with a null value.